### PR TITLE
CMake: Also take over ROOT cflags as initial flags.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,17 +2,22 @@ cmake_minimum_required(VERSION 2.6.0)
 
 # Use root-config to auto-include ROOT (root-config must be in PATH)
 EXEC_PROGRAM( root-config ARGS "--incdir" OUTPUT_VARIABLE ROOT_INCLUDE_DIR RETURN_VALUE RETVAR1)
-MESSAGE("INFO: Found ROOT include path at ${ROOT_INCLUDE_DIR}")
+MESSAGE(STATUS "Found ROOT include path at ${ROOT_INCLUDE_DIR}")
 
 EXEC_PROGRAM( root-config ARGS "--libdir" OUTPUT_VARIABLE ROOT_LIBRARY_DIR RETURN_VALUE RETVAR2)
-MESSAGE("INFO: Found ROOT library path at ${ROOT_LIBRARY_DIR}")
+MESSAGE(STATUS "Found ROOT library path at ${ROOT_LIBRARY_DIR}")
 
+EXEC_PROGRAM( root-config ARGS "--cflags" OUTPUT_VARIABLE ROOT_CFLAGS RETURN_VALUE RETVAR3)
+MESSAGE(STATUS "Using cflags from ROOT: ${ROOT_CFLAGS}")
 
-IF(${RETVAR1}${RETVAR2} MATCHES "00")
+IF(${RETVAR1}${RETVAR2}${RETVAR3} MATCHES "000")
 	include_directories(${ROOT_INCLUDE_DIR})
 
 	add_executable(jAnalyzer jAnalyzer.cpp)
 	target_link_libraries(jAnalyzer -L${ROOT_LIBRARY_DIR} Core RIO Tree Hist MathCore)
+
+	# Prefer our flags, but don't deny the ROOT ones: 
+	SET(CMAKE_CXX_FLAGS "${ROOT_CFLAGS} ${CMAKE_CXX_FLAGS}")
 ELSE()
 	MESSAGE(FATAL_ERROR "ERROR: root-config did not provide LIBRARY and INCLUDE path, is ROOT installed and root-config in PATH?")
 ENDIF()


### PR DESCRIPTION
Needed for e.g. std=c++11 - we have to compile with the
same std as the ROOT libraries for ABI compatibility,
otherwise functionality is not guaranteed.

Fixes compilation with standard ROOT 6 (c++11 ABI is required)
and also with ROOT 5 when compiled with c++11.
Should also fix for other ABIs like c++14 (untested).
