### PR TITLE
jAnalyzer: Add travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  # g++ 4.8 on linux
+  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+
+  # clang 3.4 - already with travis
+  #- if [ "$CXX" == "clang++" ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; fi
+
+  - sudo apt-get update -qq
+
+install:
+  # g++ 4.8 on linux
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
+
+  # clang 3.4 - already with travis
+  #- if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.4; fi
+  #- if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
+
+  # install ROOT. Not in Ubuntu 12.04, only later again... Travis still uses stone-aged 12.04. 
+  - sudo apt-get install x11-common libx11-6 x11-utils libX11-dev libgsl0-dev gsl-bin libxpm-dev libxft-dev gfortran build-essential libjpeg-turbo8-dev libjpeg8-dev libjpeg8-dev libjpeg-dev libtiff4-dev libxml2-dev libssl-dev libgnutls-dev libgmp3-dev libpng12-dev libldap2-dev libkrb5-dev freeglut3-dev libfftw3-dev python-dev libmysqlclient-dev libgif-dev libiodbc2 libiodbc2-dev subversion libxext-dev libxmu-dev libimlib2 gccxml
+  - mkdir root
+  - cd root
+  - wget http://root.cern.ch/download/root_v5.34.26.source.tar.gz
+  - tar xf root_v5.34.26.source.tar.gz
+  - cd root
+  - mkdir -p ${TRAVIS_BUILD_DIR}/install/
+  - ./configure linuxx8664gcc --enable-explicitlink --minimal --prefix=${TRAVIS_BUILD_DIR}/install
+  - make
+  - make install
+  - source ${TRAVIS_BUILD_DIR}/install/bin/thisroot.sh
+
+before_script:
+  - mkdir -p ${TRAVIS_BUILD_DIR}/build
+  - mkdir -p ${TRAVIS_BUILD_DIR}/install
+  - cd ${TRAVIS_BUILD_DIR}/build
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH=${TRAVIS_BUILD_DIR}/install ../src/
+
+env:
+  - PATH=${PATH}:${TRAVIS_BUILD_DIR}/install/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TRAVIS_BUILD_DIR}/install/lib
+
+script:
+  - env
+  - make
+# - make install
+# - cd ${TRAVIS_BUILD_DIR}/install
+# - jAnalyzer
+# - jAnalyzer ${TRAVIS_BUILD_DIR}/examples/run*.dat -r 1 -v -u


### PR DESCRIPTION
Builds ROOT 5.34.26, compiles jAnalyzer with gcc and clang against that.
We have to compile a full ROOT since travis is at Ubuntu 12.04 and there is no PPA.
Still fits perfectly in the 50 minutes limit for a minimal ROOT build.

jAnalyzer itself not tested yet, since cmake does not allow to install (yet).
