### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,59 @@
 language: cpp
 
+sudo: false
+
 compiler:
   - clang
   - gcc
 
-before_install:
-  # g++ 4.8 on linux
-  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-
-  # clang 3.4 - already with travis
-  #- if [ "$CXX" == "clang++" ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; fi
-
-  - sudo apt-get update -qq
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-5
+      - x11-common
+      - libx11-6
+      - x11-utils
+      - libX11-dev
+      - libgsl0-dev
+      - gsl-bin
+      - libxpm-dev
+      - libxft-dev
+      - gfortran
+      - build-essential
+      - libjpeg-turbo8-dev
+      - libjpeg8-dev
+      - libjpeg-dev
+      - libtiff4-dev
+      - libxml2-dev
+      - libssl-dev
+      - libgnutls-dev
+      - libgmp3-dev
+      - libpng12-dev
+      - libldap2-dev
+      - libkrb5-dev
+      - freeglut3-dev
+      - libfftw3-dev
+      - python-dev
+      - libmysqlclient-dev
+      - libgif-dev
+      - libiodbc2
+      - libiodbc2-dev
+      - subversion
+      - libxext-dev
+      - libxmu-dev
+      - libimlib2
+      - gccxml
 
 env:
   - ROOT_VERSION=5.34.26 PATH=${PATH}:${TRAVIS_BUILD_DIR}/install/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TRAVIS_BUILD_DIR}/install/lib
 
 install:
-  # g++ 4.8 on linux
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
-
-  # clang 3.4 - already with travis
-  #- if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.4; fi
-  #- if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
+  # g++-5 on linux
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi
 
   # install ROOT. Not in Ubuntu 12.04, only later again... Travis still uses stone-aged 12.04. 
-  - sudo apt-get install x11-common libx11-6 x11-utils libX11-dev libgsl0-dev gsl-bin libxpm-dev libxft-dev gfortran build-essential libjpeg-turbo8-dev libjpeg8-dev libjpeg8-dev libjpeg-dev libtiff4-dev libxml2-dev libssl-dev libgnutls-dev libgmp3-dev libpng12-dev libldap2-dev libkrb5-dev freeglut3-dev libfftw3-dev python-dev libmysqlclient-dev libgif-dev libiodbc2 libiodbc2-dev subversion libxext-dev libxmu-dev libimlib2 gccxml
   - mkdir root
   - cd root
   - wget http://root.cern.ch/download/root_v${ROOT_VERSION}.source.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ addons:
       - gccxml
 
 env:
-  - ROOT_VERSION=5.34.26 PATH=${PATH}:${TRAVIS_BUILD_DIR}/install/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TRAVIS_BUILD_DIR}/install/lib
+  - ROOT_VERSION=5.34.34 PATH=${PATH}:${TRAVIS_BUILD_DIR}/install/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TRAVIS_BUILD_DIR}/install/lib
 
 install:
   # g++-5 on linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,12 @@ addons:
       - libimlib2
       - gccxml
 
+cache:
+  directories:
+    - $HOME/.ccache
+
 env:
-  - ROOT_VERSION=5.34.34 PATH=${PATH}:${TRAVIS_BUILD_DIR}/install/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TRAVIS_BUILD_DIR}/install/lib
+  - ROOT_VERSION=5.34.34 PATH=/usr/lib/ccache:${PATH}:${TRAVIS_BUILD_DIR}/install/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TRAVIS_BUILD_DIR}/install/lib
 
 install:
   # g++-5 on linux


### PR DESCRIPTION
Update to be compatible with travis' container based infrastructure. 
Installation now done via apt-addon, not with "sudo" anymore. 
Also update to ROOT 5.34.34. 
Also, activate ccache - all this together burns down full travis-test-time from ~ 50 minutes to 3-4 minutes (container-infrastructure has more resources, but mostly ccache is very effective). 
Caching ROOT-install-dir would of course also be possible, but with this speedup in place, we don't need to take that additional complication. 
